### PR TITLE
Fixing squid:ClassVariableVisibilityCheck  Class variable fields should not have public accessibility

### DIFF
--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/api/okhttp/ZhihuApiOkHttpImpl.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/api/okhttp/ZhihuApiOkHttpImpl.java
@@ -46,7 +46,7 @@ public class ZhihuApiOkHttpImpl implements ZhihuApi {
         XLog.d("ZhihuApiOkHttpImpl.getStartInfoResponse request = " + request);
 
         String url = "http://news-at.zhihu.com/api/4/start-image/%d*%d";
-        url = String.format(url, request.width, request.height);
+        url = String.format(url, request.getWidth(), request.getHeight());
         GetStartInfoResponse response = get(url, GetStartInfoResponse.class);
 
         XLog.i("req = %s, resp = %s", request, response);
@@ -83,7 +83,7 @@ public class ZhihuApiOkHttpImpl implements ZhihuApi {
         XLog.d("ZhihuApiOkHttpImpl.getNewsResponse request = " + request);
 
         String url = "http://news-at.zhihu.com/api/4/news/%s";
-        url = String.format(url, request.id);
+        url = String.format(url, request.getId());
         GetNewsResponse response = get(url, GetNewsResponse.class);
 
         XLog.i("req = %s, resp = %s", request, response);
@@ -96,7 +96,7 @@ public class ZhihuApiOkHttpImpl implements ZhihuApi {
         XLog.d("ZhihuApiOkHttpImpl.getThemeResponse request = " + request);
 
         String url = "http://news-at.zhihu.com/api/4/theme/%s";
-        url = String.format(url, request.id);
+        url = String.format(url, request.getId());
         GetThemeResponse response = get(url, GetThemeResponse.class);
 
         XLog.i("req = %s, resp = %s", request, response);
@@ -122,7 +122,7 @@ public class ZhihuApiOkHttpImpl implements ZhihuApi {
         XLog.d("ZhihuApiOkHttpImpl.getShortComments request = " + request);
 
         String url = "http://news-at.zhihu.com/api/4/story/%s/short-comments";
-        url = String.format(url, request.id);
+        url = String.format(url, request.getId());
         GetShortCommentsResponse response = get(url, GetShortCommentsResponse.class);
 
         XLog.i("req = %s, resp = %s", request, response);
@@ -135,7 +135,7 @@ public class ZhihuApiOkHttpImpl implements ZhihuApi {
         XLog.d("ZhihuApiOkHttpImpl.getLongComments request = " + request);
 
         String url = "http://news-at.zhihu.com/api/4/story/%s/long-comments";
-        url = String.format(url, request.id);
+        url = String.format(url, request.getId());
         GetLongCommentsResponse response = get(url, GetLongCommentsResponse.class);
 
         XLog.i("req = %s, resp = %s", request, response);

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/api/retrofit/ZhihuApiRetrofitImpl.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/api/retrofit/ZhihuApiRetrofitImpl.java
@@ -70,7 +70,7 @@ public class ZhihuApiRetrofitImpl implements ZhihuApi {
         return new RetrofitAdapter<GetStartInfoResponse>() {
             @Override
             GetStartInfoResponse call() throws Exception {
-                return httpApi.getStartInfoResponse(request.width, request.height).execute().body();
+                return httpApi.getStartInfoResponse(request.getWidth(), request.getHeight()).execute().body();
             }
         }.get();
     }
@@ -103,7 +103,7 @@ public class ZhihuApiRetrofitImpl implements ZhihuApi {
         return new RetrofitAdapter<GetNewsResponse>() {
             @Override
             GetNewsResponse call() throws Exception {
-                return httpApi.getNewsResponse(request.id).execute().body();
+                return httpApi.getNewsResponse(request.getId()).execute().body();
             }
         }.get();
     }
@@ -114,7 +114,7 @@ public class ZhihuApiRetrofitImpl implements ZhihuApi {
         return new RetrofitAdapter<GetThemeResponse>() {
             @Override
             GetThemeResponse call() throws Exception {
-                return httpApi.getThemeResponse(request.id).execute().body();
+                return httpApi.getThemeResponse(request.getId()).execute().body();
             }
         }.get();
     }
@@ -136,7 +136,7 @@ public class ZhihuApiRetrofitImpl implements ZhihuApi {
         return new RetrofitAdapter<GetShortCommentsResponse>() {
             @Override
             GetShortCommentsResponse call() throws Exception {
-                return httpApi.getShortComments(request.id).execute().body();
+                return httpApi.getShortComments(request.getId()).execute().body();
             }
         }.get();
     }
@@ -147,7 +147,7 @@ public class ZhihuApiRetrofitImpl implements ZhihuApi {
         return new RetrofitAdapter<GetLongCommentsResponse>() {
             @Override
             GetLongCommentsResponse call() throws Exception {
-                return httpApi.getLongComments(request.id).execute().body();
+                return httpApi.getLongComments(request.getId()).execute().body();
             }
         }.get();
     }

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/pojo/request/ext/GetLongCommentsRequest.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/pojo/request/ext/GetLongCommentsRequest.java
@@ -8,9 +8,17 @@ import cn.mycommons.xiaoxiazhihu.business.pojo.request.BaseRequest;
  */
 public class GetLongCommentsRequest extends BaseRequest {
 
-    public int id;
+    private int id;
 
     public GetLongCommentsRequest(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
         this.id = id;
     }
 

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/pojo/request/ext/GetNewsRequest.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/pojo/request/ext/GetNewsRequest.java
@@ -8,11 +8,21 @@ import cn.mycommons.xiaoxiazhihu.business.pojo.request.BaseRequest;
  */
 public class GetNewsRequest extends BaseRequest {
 
-    public int id;
+    private int id;
 
     public GetNewsRequest(int id) {
         this.id = id;
     }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+
 
     @Override
     public String toString() {

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/pojo/request/ext/GetShortCommentsRequest.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/pojo/request/ext/GetShortCommentsRequest.java
@@ -8,9 +8,17 @@ import cn.mycommons.xiaoxiazhihu.business.pojo.request.BaseRequest;
  */
 public class GetShortCommentsRequest extends BaseRequest {
 
-    public int id;
+    private int id;
 
     public GetShortCommentsRequest(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
         this.id = id;
     }
 

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/pojo/request/ext/GetStartInfoRequest.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/pojo/request/ext/GetStartInfoRequest.java
@@ -8,12 +8,28 @@ import cn.mycommons.xiaoxiazhihu.business.pojo.request.BaseRequest;
  */
 public class GetStartInfoRequest extends BaseRequest {
 
-    public int width;
+    private int width;
 
-    public int height;
+    private  int height;
 
     public GetStartInfoRequest(int width, int height) {
         this.width = width;
+        this.height = height;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public void setHeight(int height) {
         this.height = height;
     }
 

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/pojo/request/ext/GetThemeRequest.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/pojo/request/ext/GetThemeRequest.java
@@ -8,9 +8,17 @@ import cn.mycommons.xiaoxiazhihu.business.pojo.request.BaseRequest;
  */
 public class GetThemeRequest extends BaseRequest {
 
-    public int id;
+    private int id;
 
     public GetThemeRequest(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
         this.id = id;
     }
 

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/CommentsFragment.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/CommentsFragment.java
@@ -39,8 +39,24 @@ public class CommentsFragment extends CommonMvpFragment<CommentsPresenter, Comme
 
     public static class CommentsExtraParam extends CommonExtraParam {
 
-        public int id;
-        public GetStoryExtraResponse storyExtraResponse;
+        private int id;
+        private GetStoryExtraResponse storyExtraResponse;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public GetStoryExtraResponse getStoryExtraResponse() {
+            return storyExtraResponse;
+        }
+
+        public void setStoryExtraResponse(GetStoryExtraResponse storyExtraResponse) {
+            this.storyExtraResponse = storyExtraResponse;
+        }
 
         @Override
         public String toString() {

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/DetailFragment.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/DetailFragment.java
@@ -32,7 +32,15 @@ public class DetailFragment extends CommonMvpFragment<DetailPresenter, DetailPre
 
     public static class DetailExtraParam extends CommonExtraParam {
 
-        public int id;
+        private int id;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
 
         @Override
         public String toString() {
@@ -143,8 +151,8 @@ public class DetailFragment extends CommonMvpFragment<DetailPresenter, DetailPre
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.menu_comments && storyExtraResponse != null) {
             CommentsFragment.CommentsExtraParam param = new CommentsFragment.CommentsExtraParam();
-            param.id = extraParam.id;
-            param.storyExtraResponse = storyExtraResponse;
+            param.setId(extraParam.id);
+            param.setStoryExtraResponse(storyExtraResponse);
             param.setFragmentClass(CommentsFragment.class);
             FragmentLauncher.launch(this, param, 0);
             return true;

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/HotnewsFragment.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/HotnewsFragment.java
@@ -249,7 +249,7 @@ public class HotnewsFragment extends CommonMvpFragment<HotnewsPresenter, Hotnews
             LastThemeStory story = (LastThemeStory) v.getTag();
             DetailFragment.DetailExtraParam param = new DetailFragment.DetailExtraParam();
             param.setFragmentClass(DetailFragment.class);
-            param.id = story.id;
+            param.setId(story.id);
             FragmentLauncher.launch(v.getContext(), param);
         }
     }

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/OtherThemeFragment.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/OtherThemeFragment.java
@@ -233,7 +233,7 @@ public class OtherThemeFragment extends MvpFragment<OtherThemePresenter, OtherTh
             LastThemeStory story = (LastThemeStory) v.getTag();
             DetailFragment.DetailExtraParam param = new DetailFragment.DetailExtraParam();
             param.setFragmentClass(DetailFragment.class);
-            param.id = story.id;
+            param.setId(story.id);
             FragmentLauncher.launch(v.getContext(), param);
         }
     }

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/TopItemFragment.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/TopItemFragment.java
@@ -51,7 +51,7 @@ public class TopItemFragment extends MvpFragment {
             public void onClick(View v) {
                 DetailFragment.DetailExtraParam param = new DetailFragment.DetailExtraParam();
                 param.setFragmentClass(DetailFragment.class);
-                param.id = topStory.id;
+                param.setId(topStory.id);
                 FragmentLauncher.launch(v.getContext(), param);
             }
         });


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:ClassVariableVisibilityCheck - “Class variable fields should not have public accessibility”. 
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
 Please let me know if you have any questions.
Fevzi Ozgul
