### PR TITLE
Fixing squid: S1118  Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/app/InjectHelp.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/app/InjectHelp.java
@@ -27,6 +27,8 @@ public class InjectHelp {
         );
     }
 
+    private InjectHelp(){}
+
     public static AppContext getAppContext() {
         return AppContext.getInstance();
     }

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/api/okhttp/OkHttpUtil.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/business/api/okhttp/OkHttpUtil.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 public class OkHttpUtil {
 
     static final int HTTP_TIME_OUT = 15;
+    private OkHttpUtil(){}
 
     public static OkHttpClient newOkHttpClient() {
         OkHttpClient client = new OkHttpClient();

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/core/log/XLog.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/core/log/XLog.java
@@ -9,6 +9,7 @@ import android.util.Log;
 public class XLog {
 
     static final String XIAOXIA_ZHIHU = "XiaoxiaZhihu";
+    private XLog(){}
 
     public static int v(String msg, Object... args) {
         if (args != null && args.length != 0) {

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/common/FragmentLauncher.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/common/FragmentLauncher.java
@@ -12,6 +12,8 @@ import android.support.v4.app.Fragment;
  */
 public class FragmentLauncher {
 
+    private FragmentLauncher(){}
+
     public static void launch(Context context, Class<? extends ICommonFragment> fragmentClass) {
         launch(context, new CommonExtraParam(fragmentClass));
     }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
Fevzi Ozgul
