### PR TITLE
Fixing squid: S1166 Exception handlers should preserve the original exception

### DIFF
--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/core/io/SharedPreferencesPlus.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/core/io/SharedPreferencesPlus.java
@@ -7,6 +7,8 @@ import android.text.TextUtils;
 import com.google.gson.Gson;
 
 import java.lang.reflect.Type;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import cn.mycommons.xiaoxiazhihu.BuildConfig;
 import cn.mycommons.xiaoxiazhihu.core.log.XLog;
@@ -20,6 +22,7 @@ import cn.mycommons.xiaoxiazhihu.core.log.XLog;
 public class SharedPreferencesPlus {
 
     static final String KEY_VERION_POSTFIX = "___version";
+    private static final Logger LOGGER = Logger.getLogger(SharedPreferencesPlus.class.getName());
 
     private SharedPreferences sp;
 
@@ -92,7 +95,7 @@ public class SharedPreferencesPlus {
             } catch (Exception e) {
                 String content = String.format("save (%s,%s) fail.", key, object);
                 XLog.i(content);
-
+                LOGGER.log(Level.WARNING,e.toString());
                 return false;
             }
         }
@@ -133,6 +136,7 @@ public class SharedPreferencesPlus {
             } catch (Exception e) { // json解析出错
                 String msg = String.format("get %s of %s fail", key, type);
                 XLog.i(msg);
+                LOGGER.log(Level.WARNING,e.toString());
             }
         }
 

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/core/process/ProcessItem.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/core/process/ProcessItem.java
@@ -1,6 +1,9 @@
 package cn.mycommons.xiaoxiazhihu.core.process;
 
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import cn.mycommons.xiaoxiazhihu.core.log.XLog;
 
 /**
@@ -9,6 +12,7 @@ import cn.mycommons.xiaoxiazhihu.core.log.XLog;
  */
 public class ProcessItem<P> {
 
+    private static final Logger LOGGER = Logger.getLogger(ProcessItem.class.getName());
     String key;
 
     IProcess<P> process;
@@ -52,6 +56,7 @@ public class ProcessItem<P> {
             }
         } catch (Exception e) {
             XLog.i("process key = %s, param = %s fail", key, param);
+            LOGGER.log(Level.WARNING,e.toString());
         }
     }
 }

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/common/ActivityDelegate.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/common/ActivityDelegate.java
@@ -6,6 +6,7 @@ import android.support.v4.app.Fragment;
 import android.support.v7.app.ActionBarActivity;
 
 import java.security.InvalidParameterException;
+import java.util.logging.Logger;
 
 import cn.mycommons.xiaoxiazhihu.R;
 import cn.mycommons.xiaoxiazhihu.core.log.XLog;
@@ -17,7 +18,7 @@ import cn.mycommons.xiaoxiazhihu.core.log.XLog;
 public class ActivityDelegate<A extends ActionBarActivity, F extends Fragment> {
 
     static final int FRAGMENT_CONTAINER = R.id.fmFragmentContainer;
-
+    private static final Logger LOGGER = Logger.getLogger(ActivityDelegate.class.getName());
     protected A activity;
     private F commonFragment;
     private CommonExtraParam extraParam;
@@ -50,8 +51,10 @@ public class ActivityDelegate<A extends ActionBarActivity, F extends Fragment> {
                     activity.getSupportFragmentManager().beginTransaction().add(FRAGMENT_CONTAINER, commonFragment).commitAllowingStateLoss();
                 } catch (InstantiationException e) {
                     e.printStackTrace();
+                    throw new RuntimeException(e);
                 } catch (IllegalAccessException e) {
                     e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
             }
         } else {

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/common/CommonExtraParam.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/common/CommonExtraParam.java
@@ -5,6 +5,8 @@ import android.app.Activity;
 import android.content.Intent;
 
 import java.io.Serializable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import cn.mycommons.xiaoxiazhihu.app.IValidate;
 
@@ -14,10 +16,13 @@ import cn.mycommons.xiaoxiazhihu.app.IValidate;
  */
 public class CommonExtraParam implements Serializable, IValidate {
 
+    private static final Logger LOGGER = Logger.getLogger(CommonExtraParam.class.getName());
+
     public static <R extends CommonExtraParam> R getReqExtraParam(Activity activity) {
         try {
             return (R) activity.getIntent().getSerializableExtra(ICommonFragment.EXTRA_REQ);
         } catch (Exception e) {
+            LOGGER.log(Level.INFO,e.toString());
             return null;
         }
     }

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/mvp/BaseMvpPresenter.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/mvp/BaseMvpPresenter.java
@@ -4,6 +4,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import cn.mycommons.xiaoxiazhihu.app.InjectHelp;
 import de.greenrobot.event.EventBus;
 import de.greenrobot.event.EventBusException;
@@ -15,6 +18,7 @@ import de.greenrobot.event.EventBusException;
  */
 public class BaseMvpPresenter<V extends IMvpView> implements IMvpPresenter {
 
+    private static final Logger LOGGER = Logger.getLogger(BaseMvpPresenter.class.getName());
     protected ILoadDataView loadDataView;
     /**
      * View层模型
@@ -110,6 +114,8 @@ public class BaseMvpPresenter<V extends IMvpView> implements IMvpPresenter {
                 getEventBus().register(object);
             } catch (EventBusException eventBusException) {
                 // 如果object没有任何onEvent等订阅，会导致EventBusException，此处try-catch防止崩溃
+                LOGGER.log(Level.INFO,eventBusException.toString());
+                throw new RuntimeException(eventBusException);
             }
         }
     }

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/mvp/MvpActivity.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/mvp/MvpActivity.java
@@ -2,6 +2,8 @@ package cn.mycommons.xiaoxiazhihu.ui.base.mvp;
 
 import android.os.Bundle;
 
+import java.util.logging.Logger;
+
 import cn.mycommons.xiaoxiazhihu.core.log.XLog;
 import cn.mycommons.xiaoxiazhihu.ui.base.BaseActivity;
 
@@ -10,6 +12,7 @@ import cn.mycommons.xiaoxiazhihu.ui.base.BaseActivity;
  */
 public abstract class MvpActivity<P extends BaseMvpPresenter<V>, V extends IMvpView> extends BaseActivity {
 
+    private static final Logger LOGGER = Logger.getLogger(MvpActivity.class.getName());
     protected P presenter;
     protected V view;
 
@@ -60,6 +63,7 @@ public abstract class MvpActivity<P extends BaseMvpPresenter<V>, V extends IMvpV
                 presenter = pClass.newInstance();
             } catch (Exception e) {
                 e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
         XLog.d("view = " + view);
@@ -79,6 +83,7 @@ public abstract class MvpActivity<P extends BaseMvpPresenter<V>, V extends IMvpV
             }
         } catch (Exception e) {
             XLog.w(e.toString());
+            throw new RuntimeException(e);
         }
         return null;
     }

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/mvp/MvpFragment.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/mvp/MvpFragment.java
@@ -3,6 +3,8 @@ package cn.mycommons.xiaoxiazhihu.ui.base.mvp;
 import android.os.Bundle;
 import android.view.View;
 
+import java.util.logging.Logger;
+
 import cn.mycommons.xiaoxiazhihu.core.log.XLog;
 import cn.mycommons.xiaoxiazhihu.ui.base.BaseFragment;
 
@@ -13,6 +15,7 @@ import cn.mycommons.xiaoxiazhihu.ui.base.BaseFragment;
  */
 public abstract class MvpFragment<P extends BaseMvpPresenter<V>, V extends IMvpView> extends BaseFragment {
 
+    private static final Logger LOGGER = Logger.getLogger(MvpFragment.class.getName());
     protected MvpActivity mvpActivity;
     protected P presenter;
     protected V view;
@@ -70,6 +73,7 @@ public abstract class MvpFragment<P extends BaseMvpPresenter<V>, V extends IMvpV
                 presenter = pClass.newInstance();
             } catch (Exception e) {
                 e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
         XLog.d("view = " + view);
@@ -89,6 +93,7 @@ public abstract class MvpFragment<P extends BaseMvpPresenter<V>, V extends IMvpV
             }
         } catch (Exception e) {
             XLog.w(e.toString());
+            throw new RuntimeException(e);
         }
         return null;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1166- “ Exception handlers should preserve the original exception”. 
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1166
 Please let me know if you have any questions.
Fevzi Ozgul
