### PR TITLE
Fixing squid: S135 Loops should not contain more than a single "break " or "continue" statement

### DIFF
--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/common/ActivityDelegate.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/common/ActivityDelegate.java
@@ -65,14 +65,8 @@ public class ActivityDelegate<A extends ActionBarActivity, F extends Fragment> {
     private boolean validate(Object obj) {
         boolean ret = false;
         do {
-            if (obj == null) {
-                break;
-            }
-            if (!(obj instanceof CommonExtraParam)) {
-                break;
-            }
             CommonExtraParam param = (CommonExtraParam) obj;
-            if (!param.validate()) {
+            if (obj == null || !(obj instanceof CommonExtraParam) || !param.validate()) {
                 break;
             }
             ret = true;

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/mvp/MvpHelper.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/mvp/MvpHelper.java
@@ -23,11 +23,10 @@ class MvpHelper<P extends BaseMvpPresenter, V extends IMvpView> {
 
         do {
             Type genType = target.getClass().getGenericSuperclass();
-            if (!(genType instanceof ParameterizedType)) {
-                break;
-            }
             Type[] params = ((ParameterizedType) genType).getActualTypeArguments();
-            if (params == null || params.length < 1) {
+            final boolean condition1 = !(genType instanceof ParameterizedType);
+            final boolean condition2 = params == null || params.length < 1;
+            if (condition1 || condition2) {
                 break;
             }
             if (params[0] != null && params[0] instanceof Class) {
@@ -46,11 +45,10 @@ class MvpHelper<P extends BaseMvpPresenter, V extends IMvpView> {
 
         do {
             Type genType = target.getClass().getGenericSuperclass();
-            if (!(genType instanceof ParameterizedType)) {
-                break;
-            }
             Type[] params = ((ParameterizedType) genType).getActualTypeArguments();
-            if (params == null || params.length < 2) {
+            final boolean condition1 = !(genType instanceof ParameterizedType);
+            final boolean condition2 = params == null || params.length < 2;
+            if (condition1 || condition2) {
                 break;
             }
             if (params[1] != null && params[1] instanceof Class) {


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S135 - “Loops should not contain more than a single "break " or "continue" statement ”.
This PR will remove 80 min TD from the project. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S135
 Please let me know if you have any questions.
 Fevzi Ozgul
