### PR TITLE
Fixing squid: S1226 Method parameters, caught exceptions and foreach variables should not be reassigned

### DIFF
--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/core/log/XLog.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/core/log/XLog.java
@@ -11,31 +11,35 @@ public class XLog {
     static final String XIAOXIA_ZHIHU = "XiaoxiaZhihu";
 
     public static int v(String msg, Object... args) {
+        String msgLocal = msg;
         if (args != null && args.length != 0) {
-            msg = String.format(msg, args);
+            msgLocal = String.format(msg, args);
         }
-        return Log.v(XIAOXIA_ZHIHU, msg);
+        return Log.v(XIAOXIA_ZHIHU, msgLocal);
     }
 
     public static int d(String msg, Object... args) {
+        String msgLocal = msg;
         if (args != null && args.length != 0) {
-            msg = String.format(msg, args);
+            msgLocal = String.format(msg, args);
         }
-        return Log.d(XIAOXIA_ZHIHU, msg);
+        return Log.d(XIAOXIA_ZHIHU, msgLocal);
     }
 
     public static int i(String msg, Object... args) {
+        String msgLocal = msg;
         if (args != null && args.length != 0) {
-            msg = String.format(msg, args);
+            msgLocal = String.format(msg, args);
         }
-        return Log.i(XIAOXIA_ZHIHU, msg);
+        return Log.i(XIAOXIA_ZHIHU, msgLocal);
     }
 
     public static int w(String msg, Object... args) {
+        String msgLocal = msg;
         if (args != null && args.length != 0) {
-            msg = String.format(msg, args);
+            msgLocal = String.format(msg, args);
         }
-        return Log.w(XIAOXIA_ZHIHU, msg);
+        return Log.w(XIAOXIA_ZHIHU, msgLocal);
     }
 
     public static int w(Throwable tr) {
@@ -43,10 +47,11 @@ public class XLog {
     }
 
     public static int e(String msg, Object... args) {
+        String msgLocal = msg;
         if (args != null && args.length != 0) {
-            msg = String.format(msg, args);
+            msgLocal = String.format(msg, args);
         }
-        return Log.e(XIAOXIA_ZHIHU, msg);
+        return Log.e(XIAOXIA_ZHIHU, msgLocal);
     }
 
     public static int e(String msg, Throwable tr) {

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/HotnewsFragment.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/HotnewsFragment.java
@@ -171,11 +171,12 @@ public class HotnewsFragment extends CommonMvpFragment<HotnewsPresenter, Hotnews
         }
 
         void bind(List<LastTemeTopStory> tops) {
+            List<LastTemeTopStory> topsLocal = tops;
             if (tops == null) {
-                tops = new ArrayList<>();
+                topsLocal = new ArrayList<>();
             }
 
-            viewPager.setAdapter(new MyFragmentPagerAdapter(fragmentManager, tops));
+            viewPager.setAdapter(new MyFragmentPagerAdapter(fragmentManager, topsLocal));
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1226 - “Method parameters, caught exceptions and foreach variables should not be reassigned”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1226
 Please let me know if you have any questions.
Fevzi Ozgul
