### PR TITLE
Fixing squid: S2696  Instance methods should not write to "static" fields

### DIFF
--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/app/AppContext.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/app/AppContext.java
@@ -17,11 +17,13 @@ public class AppContext extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        instance = this;
-
+        setInstance();
         initInject();
     }
 
+    private static void setInstance(){
+        instance = new AppContext();
+    }
     void initInject(){
         InjectHelp.init(this);
     }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S696 - “Instance methods should not write to "static" fields ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2696
 Please let me know if you have any questions.
Fevzi Ozgul
