### PR TITLE
Fixing squid: S1165 Exception classes should be immutable

### DIFF
--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/core/net/NetWorkException.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/core/net/NetWorkException.java
@@ -6,7 +6,7 @@ package cn.mycommons.xiaoxiazhihu.core.net;
  */
 public class NetWorkException extends Throwable {
 
-    private Throwable detailThrowable;
+    private final Throwable detailThrowable;
 
     public NetWorkException(Throwable throwable) {
         super(throwable);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1165- “Exception classes should be immutable”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1165
 Please let me know if you have any questions.
 Fevzi Ozgul
