### PR TITLE
Fixing squid: S1213 The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/LoadingDialogFragment.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/LoadingDialogFragment.java
@@ -15,6 +15,7 @@ public class LoadingDialogFragment extends RoboDialogFragment {
     public static final String DEFAULT_MSG = "数据加载中,请稍后……";
     private static final String DIMABLE = "dimable";
     private static final String MSG = "msg";
+    private OnCancelListener onCancelListener;
 
     public static LoadingDialogFragment newInstance() {
         return newInstance(null);
@@ -37,7 +38,7 @@ public class LoadingDialogFragment extends RoboDialogFragment {
         return f;
     }
 
-    private OnCancelListener onCancelListener;
+
 
     @NonNull
     @Override

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/common/CommonExtraParam.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/base/common/CommonExtraParam.java
@@ -14,23 +14,6 @@ import cn.mycommons.xiaoxiazhihu.app.IValidate;
  */
 public class CommonExtraParam implements Serializable, IValidate {
 
-    public static <R extends CommonExtraParam> R getReqExtraParam(Activity activity) {
-        try {
-            return (R) activity.getIntent().getSerializableExtra(ICommonFragment.EXTRA_REQ);
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    public static <R extends CommonExtraParam> R getRespExtraParam(Intent data) {
-        if (data != null) {
-            return (R) data.getSerializableExtra(ICommonFragment.EXTRA_RESP);
-        }
-        return null;
-    }
-
-    /// ************************************************************************************************************
-
     private Class<? extends ICommonFragment> fragmentClass;
 
     private Class<? extends Activity> activityClass;
@@ -48,6 +31,27 @@ public class CommonExtraParam implements Serializable, IValidate {
         this.fragmentClass = fragmentClass;
         this.activityClass = activityClass;
     }
+
+    public static <R extends CommonExtraParam> R getReqExtraParam(Activity activity) {
+        try {
+            return (R) activity.getIntent().getSerializableExtra(ICommonFragment.EXTRA_REQ);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static <R extends CommonExtraParam> R getRespExtraParam(Intent data) {
+        if (data != null) {
+            return (R) data.getSerializableExtra(ICommonFragment.EXTRA_RESP);
+        }
+        return null;
+    }
+
+    /// ************************************************************************************************************
+
+
+
+
 
     public Class<? extends ICommonFragment> getFragmentClass() {
         return fragmentClass;

--- a/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/OtherThemeFragment.java
+++ b/app/src/main/java/cn/mycommons/xiaoxiazhihu/ui/home/OtherThemeFragment.java
@@ -34,6 +34,12 @@ import cn.mycommons.xiaoxiazhihu.ui.base.mvp.MvpFragment;
 public class OtherThemeFragment extends MvpFragment<OtherThemePresenter, OtherThemePresenter.IHomeView> {
 
     static final String EXTRA_ITEM = "themeItem";
+    @Bind(R.id.swipeRefreshLayout)
+    SwipeRefreshLayout swipeRefreshLayout;
+    @Bind(R.id.recyclerView)
+    RecyclerView recyclerView;
+    ThemeItem themeItem;
+    MyAdapter adapter;
 
     public static OtherThemeFragment newInstance(ThemeItem themeItem) {
         OtherThemeFragment fragment = new OtherThemeFragment();
@@ -42,14 +48,6 @@ public class OtherThemeFragment extends MvpFragment<OtherThemePresenter, OtherTh
         fragment.setArguments(args);
         return fragment;
     }
-
-    @Bind(R.id.swipeRefreshLayout)
-    SwipeRefreshLayout swipeRefreshLayout;
-    @Bind(R.id.recyclerView)
-    RecyclerView recyclerView;
-
-    ThemeItem themeItem;
-    MyAdapter adapter;
 
     @Override
     protected int getFragmentLayout() {


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1213 - “The members of an interface declaration or class should appear in a pre-defined order”. 
This PR will remove 1h TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1213
 Please let me know if you have any questions.
Fevzi Ozgul
